### PR TITLE
Install peer dependencies so pr-bumper can shrinkwrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "",
+  "repository": "https://github.com/ciena-frost/ember-frost-action-bar",
   "scripts": {
     "build": "ember build",
     "lint": "lint-all-the-things",
@@ -28,7 +28,7 @@
     "broccoli-asset-rev": "^2.4.5",
     "chai-jquery": "^2.0.0",
     "ember-ajax": "^2.4.1",
-    "ember-cli": "2.11.1",
+    "ember-cli": "~2.11.1",
     "ember-cli-app-version": "^2.0.0",
     "ember-cli-chai": "^0.4.1",
     "ember-cli-code-coverage": "0.3.12",
@@ -62,7 +62,9 @@
     "eslint-config-frost-standard": "^6.0.0",
     "loader.js": "^4.0.10",
     "sass-lint": "^1.10.2",
-    "sinon-chai": "^2.10.0"
+    "sinon-chai": "^2.10.0",
+    "tslint": "^4.5.1",
+    "typescript": "^2.0.0"
   },
   "engines": {
     "node": ">= 5"
@@ -71,6 +73,6 @@
     "configPath": "tests/dummy/config"
   },
   "pr-bumper": {
-  "coverage": 80.00
+    "coverage": 80
   }
 }


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
 * Add peer dependencies to resolve `npm shrinkwrap --dev`
