### PR TITLE
Fix dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "6.2.0",
     "ember-frost-core": "^4.0.1",
+    "ember-prop-types": "^5.0.2",
   },
   "devDependencies": {
     "bower": "^1.8.2",
@@ -51,7 +52,6 @@
     "ember-frost-test": "2.0.0",
     "ember-hook": "^1.4.1",
     "ember-load-initializers": "^0.6.0",
-    "ember-prop-types": "^3.14.1",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "0.7.0",
     "ember-source": "~2.12.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "~2.12.0",
     "ember-disable-prototype-extensions": "^1.1.0",
-    "ember-elsewhere": "1.0.1",
     "ember-export-application-global": "^1.0.5",
     "ember-frost-test": "2.0.0",
     "ember-hook": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "ember-cli-shims": "^1.0.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-computed-decorators": "~0.3.0",
     "ember-concurrency": "~0.7.19",
     "ember-data": "~2.12.0",
     "ember-disable-prototype-extensions": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "ember-resolver": "^2.0.3",
     "ember-sinon": "0.7.0",
     "ember-source": "~2.12.0",
-    "ember-spread": "^1.2.2",
     "ember-test-utils": "4.3.2",
     "ember-truth-helpers": "^1.2.0",
     "loader.js": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "ember-cli-shims": "^1.0.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-concurrency": "~0.7.19",
     "ember-data": "~2.12.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-elsewhere": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "6.2.0",
     "ember-frost-core": "^4.0.1",
-    "ember-prop-types": "^5.0.2",
+    "ember-prop-types": "^5.0.2"
   },
   "devDependencies": {
     "bower": "^1.8.2",
@@ -35,7 +35,7 @@
     "ember-cli-chai": "^0.4.1",
     "ember-cli-code-coverage": "0.3.12",
     "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-frost-blueprints": "^1.2.1",
+    "ember-cli-frost-blueprints": "^4.0.0",
     "ember-cli-htmlbars-inline-precompile": "^0.3.6",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mirage": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "ember-sinon": "0.7.0",
     "ember-source": "~2.12.0",
     "ember-test-utils": "4.3.2",
-    "ember-truth-helpers": "^1.2.0",
     "loader.js": "^4.2.3",
     "sinon-chai": "^2.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-cli-sass": "6.2.0"
+    "ember-cli-sass": "6.2.0",
+    "ember-frost-core": "^4.0.1",
   },
   "devDependencies": {
     "bower": "^1.8.2",
@@ -47,7 +48,6 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-elsewhere": "1.0.1",
     "ember-export-application-global": "^1.0.5",
-    "ember-frost-core": "1.23.10",
     "ember-frost-test": "2.0.0",
     "ember-hook": "^1.4.1",
     "ember-load-initializers": "^0.6.0",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

Closes: https://github.com/ciena-frost/ember-frost-action-bar/issues/16

- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [X] #major# - incompatible API change

# CHANGELOG
* **Updated** to version 4 of `ember-frost-core` and move to dependency
* **Updated** to version 5 of `ember-prop-types` and move to dependency
* **Removed** `ember-spread` package since it is not used here and is now provided by `ember-frost-core` via it's own dependencies.
* **Removed** `ember-computed-decorators` package since it is not used here and is now provided by `ember-frost-core` via it's own dependencies.
* **Removed** `ember-concurrency` package since it is not used here and is now provided by `ember-frost-core` via it's own dependencies.
* **Removed** `ember-elsewhere` package since it is not used here and is now provided by `ember-frost-core` via it's own dependencies.
* **Updated** to version 4 of `ember-cli-frost-blueprints`
* **Removed** `ember-truth-helpers` since it is not used in this add-on.