### PR TITLE
Move ember-hook from devDependency to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "6.2.0",
     "ember-frost-core": "^4.0.1",
+    "ember-hook": "^1.4.2",
     "ember-prop-types": "^5.0.2"
   },
   "devDependencies": {
@@ -47,7 +48,6 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-frost-test": "2.0.0",
-    "ember-hook": "^1.4.1",
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "0.7.0",


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [ ] #none# - documentation fixes and/or test additions
- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Updated** `ember-hook` to be a dependency instead of a devDependency