### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /coverage/*
 /libpeerconnection.log
 npm-debug.log*
+package-lock.json
 testem.log
 coverage.json
 .DS_Store

--- a/.remarkignore
+++ b/.remarkignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -2,7 +2,7 @@
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon')
 
 module.exports = function (defaults) {
-  var app = new EmberAddon(defaults, {
+  let app = new EmberAddon(defaults, {
     // Add options here
   })
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "ember-cli-code-coverage": "0.3.12",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-frost-blueprints": "^4.0.0",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-cli-htmlbars-inline-precompile": "0.3.12",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mirage": "0.3.2",
     "ember-cli-mocha": "0.14.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "bower": "^1.8.2",
     "broccoli-asset-rev": "^2.4.5",
     "chai-jquery": "^2.0.0",
-    "ember-ajax": "^2.4.1",
     "ember-cli": "2.12.3",
     "ember-cli-chai": "0.4.3",
     "ember-cli-code-coverage": "0.3.12",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "ember-cli-chai": "0.4.3",
     "ember-cli-code-coverage": "0.3.12",
     "ember-cli-dependency-checker": "^1.3.0",
-    "ember-cli-frost-blueprints": "^4.0.0",
+    "ember-cli-frost-blueprints": "^5.0.1",
     "ember-cli-htmlbars-inline-precompile": "0.3.12",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-mirage": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ember-cli-sass": "6.2.0",
     "ember-frost-core": "^4.0.1",
     "ember-hook": "1.4.2",
-    "ember-prop-types": "^5.0.2"
+    "ember-prop-types": "^6.0.0"
   },
   "devDependencies": {
     "bower": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "7.1.1",
-    "ember-frost-core": "^4.0.1",
+    "ember-frost-core": "^5.0.0",
     "ember-hook": "1.4.2",
     "ember-prop-types": "^6.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-cli-sass": "6.2.0",
+    "ember-cli-sass": "7.1.1",
     "ember-frost-core": "^4.0.1",
     "ember-hook": "1.4.2",
     "ember-prop-types": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "ember-cli-mirage": "0.3.2",
     "ember-cli-mocha": "0.14.4",
     "ember-cli-shims": "^1.0.2",
-    "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "~2.12.0",
     "ember-disable-prototype-extensions": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-sass": "6.2.0",
     "ember-frost-core": "^4.0.1",
-    "ember-hook": "^1.4.2",
+    "ember-hook": "1.4.2",
     "ember-prop-types": "^5.0.2"
   },
   "devDependencies": {
@@ -48,7 +48,6 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
     "ember-frost-test": "^4.0.0",
-    "ember-hook": "1.4.2",
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
     "ember-sinon": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "ember-cli-sass": "7.1.1",
     "ember-frost-core": "^5.0.0",
     "ember-hook": "1.4.2",
-    "ember-prop-types": "^6.0.0"
+    "ember-prop-types": "^6.0.1"
   },
   "devDependencies": {
     "bower": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "chai-jquery": "^2.0.0",
     "ember-ajax": "^2.4.1",
     "ember-cli": "2.12.3",
-    "ember-cli-chai": "^0.4.1",
+    "ember-cli-chai": "0.4.3",
     "ember-cli-code-coverage": "0.3.12",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-frost-blueprints": "^4.0.0",
@@ -47,14 +47,15 @@
     "ember-data": "~2.12.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-frost-test": "2.0.0",
+    "ember-frost-test": "^4.0.0",
+    "ember-hook": "1.4.2",
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
-    "ember-sinon": "0.7.0",
+    "ember-sinon": "^0.7.0",
     "ember-source": "~2.12.0",
-    "ember-test-utils": "4.3.2",
+    "ember-test-utils": "^8.1.0",
     "loader.js": "^4.2.3",
-    "sinon-chai": "^2.10.0"
+    "sinon-chai": "^2.14.0"
   },
   "engines": {
     "node": ">= 6"

--- a/testem.js
+++ b/testem.js
@@ -1,5 +1,5 @@
 /* eslint-env node */
-var Reporter = require('ember-test-utils/reporter')
+const Reporter = require('ember-test-utils/reporter')
 
 module.exports = {
   disable_watching: true,

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
 
 module.exports = function (environment) {
-  var ENV = {
+  let ENV = {
     modulePrefix: 'dummy',
     podModulePrefix: 'dummy/pods',
     environment: environment,


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**
- [ ] #none# - documentation fixes and/or test additions
- [ ] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [X] #major# - incompatible API change

Closes: https://github.com/ciena-frost/ember-frost-action-bar/issues/16

# CHANGELOG
* **Added** the ignoring of linting of the `CHANGELOG.md` file
* **Updated** `ember-frost-test` to version `^4.0.0`
* **Updated** `ember-cli-chai` to version `0.4.3`
* **Updated** `ember-cli-mocha` to version `0.14.4`
* **Updated** `ember-test-utils` to `^8.1.0`
* **Updated** `ember-hook` to `1.4.2` and moved to dependency
* **Updated** `ember-sinon` to `^0.7.0`
* **Updated** `sinon-chai` to version `^2.14.0`
* **Removed** unused `ember-cli-sri` package
* **Updated** `ember-cli-htmlbars-inline-precompile` to `0.3.12`
* **Updated** `ember-cli-frost-blueprints` to `^5.0.1`
* **Removed** unused `ember-ajax` package
* **Updated** `ember-prop-types` to version `^6.0.1`
* **Added** package-lock to the `.gitignore`files until we are ready to migrate to node 8
* **Updated** `ember-cli-sass` to version `7.1.1`
* **Updated** `ember-frost-core` to version `^5.0.0`
